### PR TITLE
Remove stylelint-config-prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "prettier": "^2.8.1",
         "stylelint": "^15.0.0",
-        "stylelint-config-prettier": "^9.0.4",
         "stylelint-config-sass-guidelines": "^10.0.0",
         "stylelint-order": "^6.0.3",
         "stylelint-prettier": "^2.0.0",
@@ -32,7 +31,8 @@
       "peerDependencies": {
         "postcss": "^8.4.19",
         "postcss-scss": "^4.0.6",
-        "prettier": "^2.8.1"
+        "prettier": "^2.8.1",
+        "stylelint": "^14.16.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5322,21 +5322,6 @@
         "url": "https://opencollective.com/stylelint"
       }
     },
-    "node_modules/stylelint-config-prettier": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.4.tgz",
-      "integrity": "sha512-38nIGTGpFOiK5LjJ8Ma1yUgpKENxoKSOhbDNSemY7Ep0VsJoXIW9Iq/2hSt699oB9tReynfWicTAoIHiq8Rvbg==",
-      "bin": {
-        "stylelint-config-prettier": "bin/check.js",
-        "stylelint-config-prettier-check": "bin/check.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      },
-      "peerDependencies": {
-        "stylelint": ">=11.0.0"
-      }
-    },
     "node_modules/stylelint-config-sass-guidelines": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-sass-guidelines/-/stylelint-config-sass-guidelines-10.0.0.tgz",
@@ -9782,12 +9767,6 @@
           "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="
         }
       }
-    },
-    "stylelint-config-prettier": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.4.tgz",
-      "integrity": "sha512-38nIGTGpFOiK5LjJ8Ma1yUgpKENxoKSOhbDNSemY7Ep0VsJoXIW9Iq/2hSt699oB9tReynfWicTAoIHiq8Rvbg==",
-      "requires": {}
     },
     "stylelint-config-sass-guidelines": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "prettier": "^2.8.1",
     "stylelint": "^15.0.0",
-    "stylelint-config-prettier": "^9.0.4",
     "stylelint-config-sass-guidelines": "^10.0.0",
     "stylelint-order": "^6.0.3",
     "stylelint-prettier": "^2.0.0",


### PR DESCRIPTION
Removes `stylelint-config-prettier`, which we weren't actually using anyway, as it's deprecated.
