### PR TITLE
Set selector no qualifying type to warn for non-attributes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,10 @@ module.exports = {
     },
     'max-nesting-depth': 4,
     'order/properties-alphabetical-order': true,
+    'selector-no-qualifying-type': [
+      true,
+      { ignore: ['attribute'], severity: 'warning' },
+    ],
   },
   ignoreFiles: ['node_modules', 'bin', 'obj', '*.*', '!*.css', '!*.scss'],
 };


### PR DESCRIPTION
We use attribute selectors for web component props now, so don't want this to error or warn.

For other forms of qualifying type selectors, these are commonly necessary. For example, when we want to style a card as a link when it's using the anchor tag. But they still shouldn't be used unless it is necessary to use them so it's been reduced to warn instead of error.