### PR TITLE
Update the function-parentheses-space-inside rule to only error for single line

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ module.exports = {
       true,
       { ignore: ['attribute'], severity: 'warning' },
     ],
+    '@stylistic/function-parentheses-space-inside': 'never-single-line',
   },
   ignoreFiles: ['node_modules', 'bin', 'obj', '*.*', '!*.css', '!*.scss'],
 };

--- a/test/test.css
+++ b/test/test.css
@@ -33,7 +33,10 @@
 }
 
 diamond-enter {
-  animation-duration: var(--diamond-transition-duration-enter);
+  animation-duration: var(
+    --diamond-transition-duration-enter,
+    --diamond-transition-enter-delay
+  );
   animation-fill-mode: forwards;
   animation-iteration-count: 1;
   animation-name: var(--diamond-transition-enter-animation);


### PR DESCRIPTION
Since updating packages, we started receiving errors about multi-line function parenthesis – it doesn't like line-breaks which conflicts with prettier which likes the line-breaks.

The rule has been adjusted to only error for functions on a single line.

<img width="759" alt="Screenshot 2025-02-26 at 13 34 29" src="https://github.com/user-attachments/assets/4e7190bc-73b9-4559-a9d4-e7f11a29ba1f" />
